### PR TITLE
Fix missing alt text in gallery images

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -61,13 +61,13 @@
     <a href="{{ url_for('static', filename='assets/gallery/' + base_filename + '.avif') }}" data-lightbox="gallery">
         <img src="{{ url_for('static', filename='assets/gallery/' + base_filename + '.avif') }}"
              class="w-100 shadow-1-strong rounded mb-4 gallery-picture"
-             alt="alt_text">
+             alt="{{ alt_text }}">
     </a>
 </div>
 <div class="d-xl-none">
     <img src="{{ url_for('static', filename='assets/gallery/' + base_filename + '.avif') }}"
          class="w-100 shadow-1-strong rounded mb-4 gallery-picture"
-         alt="alt_text">
+         alt="{{ alt_text }}">
 </div>
 
 {% endmacro %}


### PR DESCRIPTION
## Summary
- fix alt attributes for gallery images in index.html

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684014488aa8833183e90503505ea1ea